### PR TITLE
Revert "Bump jekyll from 4.3.3 to 4.3.4"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ GEM
     http_parser.rb (0.8.0)
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
-    jekyll (4.3.4)
+    jekyll (4.3.3)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)


### PR DESCRIPTION
Reverts ken-matsui/ken-matsui.github.io#12